### PR TITLE
Adding a proper authorization

### DIFF
--- a/AppCreationScripts/Configure.ps1
+++ b/AppCreationScripts/Configure.ps1
@@ -264,6 +264,19 @@ Function ConfigureApplications
    ReplaceSetting -configFilePath $configFile -key "todo:TodoListResourceId" -newValue $serviceAadApplication.IdentifierUris
    ReplaceSetting -configFilePath $configFile -key "todo:TodoListBaseAddress" -newValue $serviceAadApplication.HomePage
 
+   $servicePropertyBladeUrl = "https://portal.azure.com/#blade/Microsoft_AAD_IAM/ManagedAppMenuBlade/Properties/objectId/"+$serviceServicePrincipal.ObjectId+"/appId/"+$serviceAadApplication.AppId
+
+   Write-Host ""
+   Write-Host -ForegroundColor Green "------------------------------------------------------------------------------------------------"
+   Write-Host -ForegroundColor Yellow "IMPORTANT: Please follow the instructions below to complete a few manual step(s) in the Azure portal":
+   Write-Host "- For 'todoListService_web_daemon_v1'"
+   Write-Host "  - Navigate to Properties tab: '$servicePropertyBladeUrl'"
+   Write-Host "  - Set 'User assignment required' to 'Yes'"
+   Write-Host "- For 'todoList_web_daemon_v1'"
+   Write-Host "  - Navigate to API Permisions: '$clientPortalUrl'"
+   Write-Host "  - Click on 'Grant admin consent for (your tenant)'."
+   Write-Host -ForegroundColor Green "------------------------------------------------------------------------------------------------"
+
    Add-Content -Value "</tbody></table></body></html>" -Path createdApps.html  
 }
 

--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ For more information, see ADAL.NET's conceptual documentation:
 - [Quickstart: Configure a client application to access web APIs (Preview)](https://docs.microsoft.com/azure/active-directory/develop/quickstart-configure-app-access-web-apis)
 - [Client credential flows](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki/Client-credential-flows)
 - [Using the acquired token to call a protected Web API](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki/Using-the-acquired-token-to-call-a-protected-Web-API)- [Client credential flows](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki/Client-credential-flows)
+- [How to: Add app roles in your application and receive them in the token](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-add-app-roles-in-azure-ad-apps)
 - [Using the acquired token to call a protected Web API](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki/Using-the-acquired-token-to-call-a-protected-Web-API)
 - [ADAL.NET's conceptual documentation](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki)
 - [Recommended pattern to acquire a token](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki/AcquireTokenSilentAsync-using-a-cached-token#recommended-pattern-to-acquire-a-token)

--- a/TodoListService/Controllers/TodoListController.cs
+++ b/TodoListService/Controllers/TodoListController.cs
@@ -46,16 +46,13 @@ namespace TodoListService.Controllers
         public IEnumerable<TodoItem> Get()
         {
             //
-            // The Scope claim tells you what permissions the client application has in the service.
-            // In this case we look for a scope value of user_impersonation, or full access to the service as the user.
+            // The `role` claim tells you what permissions the client application has in the service.
+            // In this case we look for a  `role` value of `access_as_application`
             //
-            Claim scopeClaim = ClaimsPrincipal.Current.FindFirst("http://schemas.microsoft.com/identity/claims/scope");
-            if (scopeClaim != null)
+            Claim scopeClaim = ClaimsPrincipal.Current.FindFirst("roles");
+            if (scopeClaim == null || (scopeClaim.Value != "access_as_application"))
             {
-                if (scopeClaim.Value != "user_impersonation")
-                {
-                    throw new HttpResponseException(new HttpResponseMessage { StatusCode = HttpStatusCode.Unauthorized, ReasonPhrase = "The Scope claim does not contain 'user_impersonation' or scope claim not found" });
-                }
+                throw new HttpResponseException(new HttpResponseMessage { StatusCode = HttpStatusCode.Unauthorized, ReasonPhrase = "The 'roles' claim does not contain 'access_as_application'or was not found" });
             }
 
             // A user's To Do list is keyed off of the NameIdentifier claim, which contains an immutable, unique identifier for the user.
@@ -69,13 +66,10 @@ namespace TodoListService.Controllers
         // POST api/todolist
         public void Post(TodoItem todo)
         {
-            Claim scopeClaim = ClaimsPrincipal.Current.FindFirst("http://schemas.microsoft.com/identity/claims/scope");
-            if (scopeClaim != null)
+            Claim scopeClaim = ClaimsPrincipal.Current.FindFirst("roles");
+            if (scopeClaim == null || (scopeClaim.Value != "access_as_application"))
             {
-                if (scopeClaim.Value != "user_impersonation")
-                {
-                    throw new HttpResponseException(new HttpResponseMessage { StatusCode = HttpStatusCode.Unauthorized, ReasonPhrase = "The Scope claim does not contain 'user_impersonation' or scope claim not found" });
-                }
+                throw new HttpResponseException(new HttpResponseMessage { StatusCode = HttpStatusCode.Unauthorized, ReasonPhrase = "The 'roles' claim does not contain 'access_as_application' or was not found" });
             }
 
             if (null != todo && !string.IsNullOrWhiteSpace(todo.Title))


### PR DESCRIPTION
1. Updating the code so that the controller checks that the client has the role `access_as_application`
2. Explains how to direct Azure AD to not even issue a token for client which would not be approved to get a token for the protected Web API.